### PR TITLE
Updating with atomic trade paper

### DIFF
--- a/_posts/2016-12-05-welcome.md
+++ b/_posts/2016-12-05-welcome.md
@@ -17,3 +17,4 @@ Resources:
 - [Three hardfork-related BIPs](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-January/013496.html) by Luke-Jr, 2017/1/27
 - [Spoonnet: another experimental hardfork](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-February/013542.html) by Dr Johnson Lau, 2017/2/6
 - [Draft BIP: Extended block header hardfork](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-April/013964.html) by Dr Johnson Lau, 2017/4/2
+- [Atomically Trading with Roger: Gambling on the success of a hardfork](http://homepages.cs.ncl.ac.uk/patrick.mc-corry/atomically-trading-roger.pdf) by Patrick McCorry, Ethan Heilman and Andrew Miller, 2017/07/12


### PR DESCRIPTION
Hi,

We released a new paper today that allows two parties to swap coins in the event that a hardfork activates and the blockchain splits into two forks:

It also provides a survey on previous soft/hardforks in Bitcoin, describes some of the replay protection protocols proposed in the community alongside a new proposal we call 'migration inputs'.

I think it would be relevant to add to this website - let me know if I have changed the code correctly. 

Paper:
http://homepages.cs.ncl.ac.uk/patrick.mc-corry/atomically-trading-roger.pdf
Blog post:
http://hackingdistributed.com/2017/07/11/atomic-transfer/
Coindesk:
http://www.coindesk.com/gambling-hard-fork-will-roger-ver-take-high-stakes-bitcoin-wager/